### PR TITLE
fix: correct license metadata and switch to pypa publish action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,28 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Build sdist and wheel
+        run: |
+          pip install build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,38 +11,8 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
-        id: release
         with:
           token: ${{ secrets.TOKEN_GITHUB }}
           release-type: python
-
-  publish:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install build tools
-        run: |
-          python -m pip install --upgrade pip build twine
-          pip install -r requirements.txt
-
-      - name: Build
-        run: python -m build
-
-      - name: Upload to PyPI
-        run: python -m twine upload --verbose dist/*.whl dist/*.tar.gz
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "doctoc"
 version = "0.0.1"
 description = "Generate table of contents for Markdown files"
 readme = "README.md"
-license = { text = "MIT" }
+license = { file = "LICENSE" }
 requires-python = ">=3.8"
 authors = [{ name = "Ktechhub", email = "mm@ktechhub.com" }]
 keywords = ["markdown", "table of contents"]


### PR DESCRIPTION
## Summary

Fixes the PyPI publish failure caused by invalid `license-file` metadata, and replaces the twine-based publish step with the official `pypa/gh-action-pypi-publish` action triggered on GitHub release.

## Type of change

- [x] `fix` – bug fix
- [x] `ci` – CI/CD changes

## How to test

1. Merge this PR — release-please will open a release PR
2. Merge the release PR — a GitHub release is published automatically
3. Check the Actions tab: `publish.yaml` should trigger and push to PyPI without the `license-file` error

## Checklist

- [x] Tests pass locally (`pytest tests/`)
- [x] Code is formatted (`black .`)
- [x] PR title follows `type: description` or `type(scope): description`
- [x] Relevant docs / README updated (if applicable)